### PR TITLE
Add `SingleMainWindow=true` to desktop file

### DIFF
--- a/res/bilibili.desktop
+++ b/res/bilibili.desktop
@@ -16,3 +16,4 @@ StartupNotify=true
 Terminal=false
 TerminalOptions=
 Type=Application
+SingleMainWindow=true


### PR DESCRIPTION
This indicates only one application can be opened at the same time, and
will hide "Open New Window" menu action in Plasma.