### PR TITLE
feat: upgrade Electron 28→43 for NVIDIA GPU acceleration on Wayland

### DIFF
--- a/.github/ISSUE_TEMPLATE/nvidia-gpu-acceleration.md
+++ b/.github/ISSUE_TEMPLATE/nvidia-gpu-acceleration.md
@@ -1,0 +1,96 @@
+---
+name: 'NVIDIA GPU acceleration on Wayland: upgrade Electron to 43+ (Chromium 150)'
+about: 'NVIDIA GPU rendering + VA-API NVDEC hardware video decode on Wayland'
+title: 'feat: support NVIDIA GPU acceleration (Electron 43+)'
+labels: enhancement
+assignees: ''
+---
+
+## Background
+
+On **NVIDIA GPU + Wayland** systems (e.g. GTX 1660 Ti / KDE Plasma), the current Electron 28 (Chromium 120) build has two GPU acceleration blockers:
+
+1. **GPU rendering fallback**: `--use-gl=egl` crashes with "Passthrough is not supported" (exit 133). `--use-gl=angle --use-angle=gl` works but the GPU process may fall back to SwiftShader in some configurations.
+
+2. **VA-API video decode blocked**: Chromium's `vaapi_wrapper` has a hard-coded check at `vaapi_wrapper.cc:130`:
+
+   ```
+   WARNING:vaapi_wrapper.cc:130] Should skip nVidia device named: nvidia-drm
+   ```
+
+   This causes Chromium to skip VA-API initialization on NVIDIA GPUs entirely. The GPU process shows `dec: 0%` in `nvidia-smi dmon`.
+
+3. **System proxy conflict** (Chromium 150+): When a system proxy (e.g. Clash at `127.0.0.1:7897`) is active, the local debug domain `bilipc.bilibili.com` (host-rules → `localhost:3031`) goes through the proxy, which cannot resolve the fake domain and returns `ERR_CONNECTION_CLOSED (-100)` → blank window.
+
+## Root Cause
+
+### For VA-API decode
+
+The feature `VaapiOnNvidiaGPUs` (introduced in Chromium 130) is required to bypass the NVIDIA device skip in `vaapi_wrapper`. This feature **does not exist** in Chromium 120 (Electron 28).
+
+Additionally, Chromium 150 renamed the VA-API decode feature from `VaapiVideoDecoder` (the old name used in Chromium 120) to `AcceleratedVideoDecodeLinuxGL` / `AcceleratedVideoDecodeLinuxZeroCopyGL`.
+
+### For the proxy issue
+
+Chromium 150's NetworkService (out-of-process network stack) honors the system proxy unconditionally. `--proxy-bypass-rules` command-line flag does not override system proxy settings. Must use `session.defaultSession.setProxy()` in the Electron main process with `proxyBypassRules` to bypass.
+
+## Required Changes
+
+### 1. Upgrade Electron from 28.2.1 → 43.1.1 (or ≥ 130)
+
+- `conf/build.json`: `"electronVersion": "43.1.1"`
+- `package.json`: `"electron": "^43.1.1"`
+- `tools/update-electron.sh`: `electron_version="43.1.1"`
+
+### 2. Add Chromium 150 certificate-error handler
+
+Chromium 150 no longer fully trusts `--ignore-certificate-errors` for navigation. Must add an explicit `certificate-error` event handler:
+
+```ts
+app.on("certificate-error", (event, _webContents, url, _error, _certificate, callback) => {
+  if (url.startsWith("https://bilipc.bilibili.com") || url.startsWith("https://localhost:3031")) {
+    event.preventDefault();
+    callback(true);
+  } else {
+    callback(false);
+  }
+});
+```
+
+### 3. Add proxy bypass for system proxy compatibility
+
+```ts
+app.whenReady().then(() => {
+  const proxyUrl = (process.env.HTTPS_PROXY || process.env.HTTP_PROXY || "").trim();
+  session.defaultSession.setProxy({
+    proxyRules: proxyUrl.replace(/^https?:\/\//i, "").replace(/\/+$/, "") || undefined,
+    proxyBypassRules: "bilipc.bilibili.com,localhost,127.0.0.1",
+  }).catch(() => {});
+});
+```
+
+### 4. Update `bilibili-flags.conf` recommended options
+
+Replace old `VaapiVideoDecoder` with new GPU/VA-API feature names:
+
+```
+--enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,VaapiOnNvidiaGPUs,VaapiIgnoreDriverChecks,PlatformHEVCDecoderSupport
+```
+
+`VaapiOnNvidiaGPUs` is the critical new feature that enables VA-API → NVDEC hardware decode on NVIDIA GPUs.
+
+## Compatibility Note
+
+- Electron 43's screen cursor regression (#42519) is **bypassed** on Wayland via the existing `cursor-tool` binary (reads `/dev/input/event*` directly), so upgrading is safe for Wayland users.
+- X11 users may still be affected by #42519 and should test before upgrading.
+
+## Reference Fork
+
+A working fork with all changes applied is available at:
+https://github.com/wings1848/bilibili-linux/tree/feat/electron43-gpu
+
+The GPU acceleration has been verified:
+- ✅ GPU rendering: NVIDIA (gpu-process 379 MiB VRAM, `sm 14-15%`)
+- ✅ NVDEC hardware decode: `dec 5-7%` on HEVC video
+- ✅ No blank screen / SSL errors
+- ✅ System proxy preserved (bypass only bilipc/localhost)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -517,7 +517,6 @@ jobs:
     needs:
       - build-linux-simple
       - build-linux-package
-      - build-win
       - build-deepin
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -519,6 +519,8 @@ jobs:
       - build-linux-package
       - build-deepin
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,9 +107,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [22.x]
         ARCH: ['x64', 'arm64', 'loong64', 'loongarch64']
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
       - uses: actions/checkout@v2
@@ -182,9 +181,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [22.x]
         ARCH: ['x64', 'loong64']
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
       - uses: actions/checkout@v2
@@ -253,9 +251,8 @@ jobs:
     container: scottyhardy/docker-wine
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [22.x]
         ARCH: ['x64']
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
       - uses: actions/checkout@v2
@@ -267,7 +264,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - name: Prepare
         run: |
           set -x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+      - name: Cache bilibili Windows installer
+        uses: actions/cache@v4
+        with:
+          path: cache/
+          key: bili-cache-${{ hashFiles('tools/update-bilibili.sh') }}
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -114,6 +119,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+      - name: Cache electron binary (zip + extracted)
+        uses: actions/cache@v4
+        with:
+          path: |
+            cache/electron-v*.zip
+            electron/
+          key: electron-${{ matrix.ARCH }}-${{ hashFiles('tools/update-electron.sh') }}
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -186,6 +198,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Cache pnpm store + electron-builder
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.local/share/pnpm/store
+            ~/.cache/electron-builder
+            node_modules/
+          key: pnpm-builder-${{ hashFiles('pnpm-lock.yaml') }}-${{ matrix.ARCH }}
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -324,6 +344,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Cache electron binary (zip + extracted)
+        uses: actions/cache@v4
+        with:
+          path: |
+            cache/electron-v*.zip
+            electron/
+          key: electron-deepin-${{ matrix.ARCH }}-${{ hashFiles('tools/update-electron.sh') }}
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,6 +265,7 @@ jobs:
 
   build-win:
     name: Build Windows
+    continue-on-error: true
     needs:
       - build-app
     runs-on: ubuntu-latest
@@ -544,6 +545,7 @@ jobs:
     needs:
       - build-linux-simple
       - build-linux-package
+      - build-win
       - build-deepin
     runs-on: ubuntu-latest
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.codegraph/

--- a/.local-bin/asar
+++ b/.local-bin/asar
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec npx asar "$@"

--- a/README.MD
+++ b/README.MD
@@ -75,53 +75,68 @@ Emerge from [gentoo-zh overlay](https://github.com/microcai/gentoo-zh/tree/maste
 
 ### 额外补充
 
-如果阁下不喜欢电脑多装一个 Electron，可以自行提取发布版的 `app.asar` 并使用已安装 Electron 启动，建议的 Electron 版本是：`43.1.1`（本 fork 版本；旧版 Electron 28 不支持 NVIDIA VA-API 硬解）
+如果阁下不喜欢电脑多装一个 Electron，可以自行提取发布版的 `app.asar` 并使用已安装 Electron 启动，建议的 Electron 版本是：`43.1.1`（`VaapiOnNvidiaGPUs` 需要 Electron 43+ / Chromium 130+）
 
 ## GPU 加速配置
 
-### NVIDIA GPU (Wayland + Electron 43+)
+> **Arch Linux 用户**：推荐使用 AUR 包 [`bilibili-gpu-bin`](https://aur.archlinux.org/packages/bilibili-gpu-bin)，自动处理 GPU 检测和 flags 注入。
 
-如果你的系统使用 **NVIDIA GPU + Wayland**，且已升级至 **Electron 43（Chromium 150）**或更高版本（如本 fork），配置以下 flags 可实现 **GPU 渲染加速 + NVDEC 硬件视频解码**：
+Electron 43 (Chromium 150) 支持 Linux 下 VA-API 硬件视频解码。以下为推荐配置：
+
+### NVIDIA GPU
 
 1. 安装 VA-API → NVDEC 后端：
    ```bash
    # Arch Linux
    sudo pacman -S libva-nvidia-driver
+   # Debian/Ubuntu
+   sudo apt install libva-nvidia-driver
    ```
 
-2. 在 `~/.config/bilibili/bilibili-flags.conf` 中配置：
+2. 设置环境变量（libva 需要此变量定位 NVIDIA 后端）：
+   ```bash
+   export LIBVA_DRIVER_NAME=nvidia
+   ```
+
+3. 在 `~/.config/bilibili-linux/bilibili-flags.conf` 中配置：
 
    ```
    --ignore-gpu-blocklist
-   --use-gl=angle
-   --use-angle=gl
    --enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,VaapiOnNvidiaGPUs,VaapiIgnoreDriverChecks,PlatformHEVCDecoderSupport
    --enable-gpu-rasterization
    --enable-zero-copy
    --disable-gpu-sandbox
    ```
 
-   > **关键说明**：
-   > - `VaapiOnNvidiaGPUs` **必需**，Chromium 130+ 新增，绕过 vaapi_wrapper 对 NVIDIA 设备的跳过检查
-   > - `AcceleratedVideoDecodeLinuxGL` 取代了旧版 `VaapiVideoDecoder`（Chromium 120- 的旧名）
-   > - Electron 28（AUR 版 bilibili-bin）**不支持**以上新 feature，NVIDIA 上视频硬解无法启用
+   > **说明**：
+   > - `VaapiOnNvidiaGPUs` (Chromium 130+) 绕过 vaapi_wrapper 对 NVIDIA 设备的跳过检查，是 NVIDIA 硬解的必需 feature
+   > - `AcceleratedVideoDecodeLinuxGL` / `AcceleratedVideoDecodeLinuxZeroCopyGL` 为 Chromium 150 推荐的 GL 零拷贝解码路径
+   > - Electron 28 不支持以上 feature，NVIDIA 视频硬解需要 Electron 43+
 
-3. 在播放器设置中开启「优先使用 HEVC/H.265 编码视频播放」（GTX 1660 Ti 及更早 GPU 不支持 AV1 硬解）
-
-### Intel/AMD GPU
-
-Intel 核显和 AMD 独显/核显默认 VA-API 支持较好：
+### Intel / AMD GPU
 
 ```
 --ignore-gpu-blocklist
---enable-features=VaapiVideoDecoder,VaapiIgnoreDriverChecks
+--enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,VaapiVideoDecoder,VaapiIgnoreDriverChecks,PlatformHEVCDecoderSupport
 --enable-gpu-rasterization
 --enable-zero-copy
+--disable-gpu-sandbox
 ```
+
+Intel 核显与 AMD 独显/核显使用 Mesa VA-API 后端，无需额外安装驱动或设置环境变量。
+
+### 验证硬解
+
+```bash
+cat /proc/$(pgrep -f "type=gpu-process.*bilibili")/fdinfo/* | grep drm-engine-video
+```
+
+非零数值表示 GPU 解码引擎正在工作。也可访问 `chrome://gpu` 查看 "Video Decode" 状态。
 
 ### 注意
 
-- 如果系统开启了系统代理（如 Clash），本地调试域名 `bilipc.bilibili.com`（host-rules 映射到 localhost）经代理无法解析，会导致页面白屏（`ERR_CONNECTION_CLOSED`）。本 fork 已内置修复，会自动放行 `bilipc` 和 `localhost` 绕过代理。
+- `--use-gl=angle --use-angle=gl` 在部分 Linux 桌面环境（尤其是 Wayland）下可能导致 VA-API 解码失效，建议使用 Electron 默认的 EGL/GLX 后端。
+- 如果系统开启了代理（如 Clash），Electron 43+ 版本已内置代理绕过处理（放行 `bilipc` 和 `localhost`）。
 
 ## 开发者工具
 

--- a/README.MD
+++ b/README.MD
@@ -77,23 +77,57 @@ Emerge from [gentoo-zh overlay](https://github.com/microcai/gentoo-zh/tree/maste
 
 如果阁下不喜欢电脑多装一个 Electron，可以自行提取发布版的 `app.asar` 并使用已安装 Electron 启动，建议的 Electron 版本是：`28.2.1`
 
-## Flag参数配置
+## GPU 加速配置
 
-支持的参数列表：
-https://www.electronjs.org/docs/latest/api/command-line-switches
+### NVIDIA GPU (Wayland + Electron 43+)
 
-1. 创建 `flags` 文件
+如果你的系统使用 **NVIDIA GPU + Wayland**，且已升级至 **Electron 43（Chromium 150）**或更高版本（如本 fork），配置以下 flags 可实现 **GPU 渲染加速 + NVDEC 硬件视频解码**：
 
-   在 `~/.config/bilibili` 目录下创建 `bilibili-flags.conf` 文件
+1. 安装 VA-API → NVDEC 后端：
+   ```bash
+   # Arch Linux
+   sudo pacman -S libva-nvidia-driver
+   ```
 
-2. 填写配置
+2. 在 `~/.config/bilibili/bilibili-flags.conf` 中配置：
 
    ```
-   --disable-gpu
-   --key=value
+   --ignore-gpu-blocklist
+   --use-gl=angle
+   --use-angle=gl
+   --enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,VaapiOnNvidiaGPUs,VaapiIgnoreDriverChecks,PlatformHEVCDecoderSupport
+   --enable-gpu-rasterization
+   --enable-zero-copy
+   --disable-gpu-sandbox
    ```
+
+   > **关键说明**：
+   > - `VaapiOnNvidiaGPUs` **必需**，Chromium 130+ 新增，绕过 vaapi_wrapper 对 NVIDIA 设备的跳过检查
+   > - `AcceleratedVideoDecodeLinuxGL` 取代了旧版 `VaapiVideoDecoder`（Chromium 120- 的旧名）
+   > - Electron 28（AUR 版 bilibili-bin）**不支持**以上新 feature，NVIDIA 上视频硬解无法启用
+
+3. 在播放器设置中开启「优先使用 HEVC/H.265 编码视频播放」（GTX 1660 Ti 及更早 GPU 不支持 AV1 硬解）
+
+### Intel/AMD GPU
+
+Intel 核显和 AMD 独显/核显默认 VA-API 支持较好：
+
+```
+--ignore-gpu-blocklist
+--enable-features=VaapiVideoDecoder,VaapiIgnoreDriverChecks
+--enable-gpu-rasterization
+--enable-zero-copy
+```
+
+### 注意
+
+- 如果系统开启了系统代理（如 Clash），本地调试域名 `bilipc.bilibili.com`（host-rules 映射到 localhost）经代理无法解析，会导致页面白屏（`ERR_CONNECTION_CLOSED`）。本 fork 已内置修复，会自动放行 `bilipc` 和 `localhost` 绕过代理。
 
 ## 开发者工具
+
+### F12 开发者面板
+
+现已支持自行打开开发者工具，方法如下：
 
 现已支持自行打开开发者工具，方法如下：
 

--- a/README.MD
+++ b/README.MD
@@ -75,7 +75,7 @@ Emerge from [gentoo-zh overlay](https://github.com/microcai/gentoo-zh/tree/maste
 
 ### 额外补充
 
-如果阁下不喜欢电脑多装一个 Electron，可以自行提取发布版的 `app.asar` 并使用已安装 Electron 启动，建议的 Electron 版本是：`28.2.1`
+如果阁下不喜欢电脑多装一个 Electron，可以自行提取发布版的 `app.asar` 并使用已安装 Electron 启动，建议的 Electron 版本是：`43.1.1`（本 fork 版本；旧版 Electron 28 不支持 NVIDIA VA-API 硬解）
 
 ## GPU 加速配置
 

--- a/README_en.MD
+++ b/README_en.MD
@@ -78,53 +78,68 @@ Emerge from [gentoo-zh overlay](https://github.com/microcai/gentoo-zh/tree/maste
 
 ### Additional Notes
 
-If you don't want to install another Electron on your computer, you can extract `app.asar` from the release version and run it with your already installed Electron. The recommended Electron version is: `43.1.1` (this fork; Electron 28 does not support NVIDIA VA-API hardware decode)
+If you don't want to install another Electron on your computer, you can extract `app.asar` from the release version and run it with your already installed Electron. The recommended Electron version is: `43.1.1` (`VaapiOnNvidiaGPUs` requires Electron 43+ / Chromium 130+)
 
 ## GPU Acceleration Configuration
 
-### NVIDIA GPU (Wayland + Electron 43+)
+> **Arch Linux users**: Use AUR package [`bilibili-gpu-bin`](https://aur.archlinux.org/packages/bilibili-gpu-bin) for automatic GPU detection and flag injection.
 
-For **NVIDIA GPU + Wayland** with **Electron 43 (Chromium 150)** or later (as in this fork), the following flags enable **GPU rendering + NVDEC hardware video decoding**:
+Electron 43 (Chromium 150) supports VA-API hardware video decoding on Linux. Below are the recommended configurations:
 
-1. Install VA-API → NVDEC backend:
+### NVIDIA GPU
+
+1. Install the VA-API → NVDEC backend:
    ```bash
    # Arch Linux
    sudo pacman -S libva-nvidia-driver
+   # Debian/Ubuntu
+   sudo apt install libva-nvidia-driver
    ```
 
-2. Configure in `~/.config/bilibili/bilibili-flags.conf`:
+2. Set the environment variable (libva needs this to find the NVIDIA backend):
+   ```bash
+   export LIBVA_DRIVER_NAME=nvidia
+   ```
+
+3. Configure in `~/.config/bilibili-linux/bilibili-flags.conf`:
 
    ```
    --ignore-gpu-blocklist
-   --use-gl=angle
-   --use-angle=gl
    --enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,VaapiOnNvidiaGPUs,VaapiIgnoreDriverChecks,PlatformHEVCDecoderSupport
    --enable-gpu-rasterization
    --enable-zero-copy
    --disable-gpu-sandbox
    ```
 
-   > **Key notes**:
-   > - `VaapiOnNvidiaGPUs` is **required** – Chromium 130+ only, bypasses vaapi_wrapper's NVIDIA device skip
-   > - `AcceleratedVideoDecodeLinuxGL` replaces the old `VaapiVideoDecoder` (Chromium 120- name)
-   > - Electron 28 (AUR bilibili-bin) **lacks** these new features – hardware video decode on NVIDIA cannot work
+   > **Notes**:
+   > - `VaapiOnNvidiaGPUs` (Chromium 130+) bypasses vaapi_wrapper's NVIDIA device skip check — required for NVIDIA hardware decode
+   > - `AcceleratedVideoDecodeLinuxGL` / `AcceleratedVideoDecodeLinuxZeroCopyGL` are the recommended GL zero-copy decode paths for Chromium 150
+   > - Electron 28 lacks these features — NVIDIA hardware video decode requires Electron 43+
 
-3. Enable "Prefer HEVC/H.265" in player settings (GTX 1660 Ti and older GPUs lack AV1 hardware decode)
-
-### Intel/AMD GPU
-
-Intel iGPUs and AMD GPUs have good VA-API support by default:
+### Intel / AMD GPU
 
 ```
 --ignore-gpu-blocklist
---enable-features=VaapiVideoDecoder,VaapiIgnoreDriverChecks
+--enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,VaapiVideoDecoder,VaapiIgnoreDriverChecks,PlatformHEVCDecoderSupport
 --enable-gpu-rasterization
 --enable-zero-copy
+--disable-gpu-sandbox
 ```
+
+Intel iGPUs and AMD GPUs use the Mesa VA-API backend — no additional driver or environment variables needed.
+
+### Verifying Hardware Decode
+
+```bash
+cat /proc/$(pgrep -f "type=gpu-process.*bilibili")/fdinfo/* | grep drm-engine-video
+```
+
+A non-zero value indicates the GPU decode engine is working. You can also visit `chrome://gpu` to check the "Video Decode" status.
 
 ### Note
 
-- If you have a system proxy enabled (e.g. Clash), the local debug domain `bilipc.bilibili.com` (host-rules mapped to localhost) cannot be resolved through the proxy and will cause a blank white screen (`ERR_CONNECTION_CLOSED`). This fork includes a built-in fix that automatically bypasses the proxy for `bilipc` and `localhost`.
+- `--use-gl=angle --use-angle=gl` may break VA-API decoding on some desktop environments (especially Wayland). The default EGL/GLX backend is recommended.
+- If using a system proxy (e.g. Clash), Electron 43+ includes built-in proxy bypass handling for `bilipc` and `localhost`.
 
 ## Developer Tools
 

--- a/README_en.MD
+++ b/README_en.MD
@@ -80,23 +80,55 @@ Emerge from [gentoo-zh overlay](https://github.com/microcai/gentoo-zh/tree/maste
 
 If you don't want to install another Electron on your computer, you can extract `app.asar` from the release version and run it with your already installed Electron. The recommended Electron version is: `28.2.1`
 
-## Flag Configuration
+## GPU Acceleration Configuration
 
-List of supported flags:
-https://www.electronjs.org/docs/latest/api/command-line-switches
+### NVIDIA GPU (Wayland + Electron 43+)
 
-1. Create a `flags` file
+For **NVIDIA GPU + Wayland** with **Electron 43 (Chromium 150)** or later (as in this fork), the following flags enable **GPU rendering + NVDEC hardware video decoding**:
 
-   Create a `bilibili-flags.conf` file in the `~/.config/bilibili` directory.
+1. Install VA-API → NVDEC backend:
+   ```bash
+   # Arch Linux
+   sudo pacman -S libva-nvidia-driver
+   ```
 
-2. Fill in the configuration
+2. Configure in `~/.config/bilibili/bilibili-flags.conf`:
 
    ```
-   --disable-gpu
-   --key=value
+   --ignore-gpu-blocklist
+   --use-gl=angle
+   --use-angle=gl
+   --enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,VaapiOnNvidiaGPUs,VaapiIgnoreDriverChecks,PlatformHEVCDecoderSupport
+   --enable-gpu-rasterization
+   --enable-zero-copy
+   --disable-gpu-sandbox
    ```
+
+   > **Key notes**:
+   > - `VaapiOnNvidiaGPUs` is **required** – Chromium 130+ only, bypasses vaapi_wrapper's NVIDIA device skip
+   > - `AcceleratedVideoDecodeLinuxGL` replaces the old `VaapiVideoDecoder` (Chromium 120- name)
+   > - Electron 28 (AUR bilibili-bin) **lacks** these new features – hardware video decode on NVIDIA cannot work
+
+3. Enable "Prefer HEVC/H.265" in player settings (GTX 1660 Ti and older GPUs lack AV1 hardware decode)
+
+### Intel/AMD GPU
+
+Intel iGPUs and AMD GPUs have good VA-API support by default:
+
+```
+--ignore-gpu-blocklist
+--enable-features=VaapiVideoDecoder,VaapiIgnoreDriverChecks
+--enable-gpu-rasterization
+--enable-zero-copy
+```
+
+### Note
+
+- If you have a system proxy enabled (e.g. Clash), the local debug domain `bilipc.bilibili.com` (host-rules mapped to localhost) cannot be resolved through the proxy and will cause a blank white screen (`ERR_CONNECTION_CLOSED`). This fork includes a built-in fix that automatically bypasses the proxy for `bilipc` and `localhost`.
 
 ## Developer Tools
+
+### F12 Developer Panel
 
 You can now open the developer tools yourself:
 

--- a/README_en.MD
+++ b/README_en.MD
@@ -78,7 +78,7 @@ Emerge from [gentoo-zh overlay](https://github.com/microcai/gentoo-zh/tree/maste
 
 ### Additional Notes
 
-If you don't want to install another Electron on your computer, you can extract `app.asar` from the release version and run it with your already installed Electron. The recommended Electron version is: `28.2.1`
+If you don't want to install another Electron on your computer, you can extract `app.asar` from the release version and run it with your already installed Electron. The recommended Electron version is: `43.1.1` (this fork; Electron 28 does not support NVIDIA VA-API hardware decode)
 
 ## GPU Acceleration Configuration
 

--- a/aur/.SRCINFO
+++ b/aur/.SRCINFO
@@ -1,15 +1,15 @@
 pkgbase = bilibili-gpu-bin
-	pkgdesc = Bilibili client for Linux (Electron 43, NVIDIA GPU acceleration fork)
+	pkgdesc = Bilibili client for Linux (Electron 43, auto-detected GPU acceleration)
 	pkgver = 1.17.9
-	pkgrel = 7
+	pkgrel = 8
 	url = https://github.com/wings1848/bilibili-linux
+	install = bilibili-gpu-bin.install
 	arch = x86_64
 	license = MIT
 	depends = gtk3
 	depends = libnotify
 	depends = nss
 	depends = libva
-	depends = libva-nvidia-driver
 	depends = libxtst
 	depends = xdg-utils
 	depends = at-spi2-core
@@ -17,13 +17,14 @@ pkgbase = bilibili-gpu-bin
 	depends = libxkbcommon
 	depends = mesa
 	depends = alsa-lib
+	optdepends = libva-nvidia-driver: VA-API backend for NVIDIA GPU video decode (NVDEC)
 	optdepends = python-faster-whisper: AI subtitle transcription
 	provides = bilibili=1.17.9
 	conflicts = bilibili
 	conflicts = bilibili-bin
 	source = bilibili.svg::https://raw.githubusercontent.com/wings1848/bilibili-linux/v1.17.9-1/res/icons/bilibili.svg
-	sha256sums = SKIP
+	sha256sums = 7cf1a17b2a0932927396d5fd6a5c7c5b418222a405cc99322d0a730741f41b89
 	source_x86_64 = bilibili-v1.17.9-1-x64.tar.gz::https://github.com/wings1848/bilibili-linux/releases/download/v1.17.9-1/bilibili-v1.17.9-1-x64.tar.gz
-	sha256sums_x86_64 = SKIP
+	sha256sums_x86_64 = 3657b4f5d0d29ad1917a0476d97e07cfee76cfc2532c635566a6025b0297e1c5
 
 pkgname = bilibili-gpu-bin

--- a/aur/.SRCINFO
+++ b/aur/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = bilibili-gpu-bin
 	pkgdesc = Bilibili client for Linux (Electron 43, NVIDIA GPU acceleration fork)
 	pkgver = 1.17.9
-	pkgrel = 1
+	pkgrel = 7
 	url = https://github.com/wings1848/bilibili-linux
 	arch = x86_64
 	license = MIT
@@ -21,7 +21,9 @@ pkgbase = bilibili-gpu-bin
 	provides = bilibili=1.17.9
 	conflicts = bilibili
 	conflicts = bilibili-bin
-	source_x86_64 = bilibili-1.17.9-x86_64.AppImage::https://github.com/wings1848/bilibili-linux/releases/download/v1.17.9-1/bilibili-1.17.9-x86_64.AppImage
+	source = bilibili.svg::https://raw.githubusercontent.com/wings1848/bilibili-linux/v1.17.9-1/res/icons/bilibili.svg
+	sha256sums = SKIP
+	source_x86_64 = bilibili-v1.17.9-1-x64.tar.gz::https://github.com/wings1848/bilibili-linux/releases/download/v1.17.9-1/bilibili-v1.17.9-1-x64.tar.gz
 	sha256sums_x86_64 = SKIP
 
 pkgname = bilibili-gpu-bin

--- a/aur/.SRCINFO
+++ b/aur/.SRCINFO
@@ -1,0 +1,27 @@
+pkgbase = bilibili-gpu-bin
+	pkgdesc = Bilibili client for Linux (Electron 43, NVIDIA GPU acceleration fork)
+	pkgver = 1.17.9
+	pkgrel = 1
+	url = https://github.com/wings1848/bilibili-linux
+	arch = x86_64
+	license = MIT
+	depends = gtk3
+	depends = libnotify
+	depends = nss
+	depends = libva
+	depends = libva-nvidia-driver
+	depends = libxtst
+	depends = xdg-utils
+	depends = at-spi2-core
+	depends = cups
+	depends = libxkbcommon
+	depends = mesa
+	depends = alsa-lib
+	optdepends = python-faster-whisper: AI subtitle transcription
+	provides = bilibili=1.17.9
+	conflicts = bilibili
+	conflicts = bilibili-bin
+	source_x86_64 = bilibili-1.17.9-x86_64.AppImage::https://github.com/wings1848/bilibili-linux/releases/download/v1.17.9-1/bilibili-1.17.9-x86_64.AppImage
+	sha256sums_x86_64 = SKIP
+
+pkgname = bilibili-gpu-bin

--- a/aur/.gitignore
+++ b/aur/.gitignore
@@ -1,0 +1,2 @@
+bilibili-v*.tar.gz
+bilibili.svg

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,16 +1,18 @@
 # Maintainer: wingsbutterfly <wingsbutterfly@users.noreply.github.com>
 # Contributor: msojocs <jiyecafe@gmail.com>
 #
-# NVIDIA GPU acceleration fork — Electron 43 (Chromium 150) + VaapiOnNvidiaGPUs
-# for NVDEC hardware video decode on NVIDIA GPUs under Wayland.
+# GPU-accelerated bilibili client — Electron 43 (Chromium 150).
+# Auto-detects GPU at runtime for VA-API hardware video decode:
+#   NVIDIA → VaapiOnNvidiaGPUs (libva-nvidia-driver → NVDEC)
+#   Intel / AMD → VaapiVideoDecoder (Mesa Gallium)
 # Original upstream: https://github.com/msojocs/bilibili-linux
 # Fork: https://github.com/wings1848/bilibili-linux
 
 pkgname=bilibili-gpu-bin
 _pkgreal=bilibili
 pkgver=1.17.9
-pkgrel=7
-pkgdesc="Bilibili client for Linux (Electron 43, NVIDIA GPU acceleration fork)"
+pkgrel=8
+pkgdesc="Bilibili client for Linux (Electron 43, auto-detected GPU acceleration)"
 arch=('x86_64')
 url="https://github.com/wings1848/bilibili-linux"
 license=('MIT')
@@ -19,7 +21,6 @@ depends=(
   'libnotify'
   'nss'
   'libva'
-  'libva-nvidia-driver'
   'libxtst'
   'xdg-utils'
   'at-spi2-core'
@@ -29,14 +30,16 @@ depends=(
   'alsa-lib'
 )
 optdepends=(
+  'libva-nvidia-driver: VA-API backend for NVIDIA GPU video decode (NVDEC)'
   'python-faster-whisper: AI subtitle transcription'
 )
 conflicts=('bilibili' 'bilibili-bin')
 provides=("${_pkgreal}=${pkgver}")
 source_x86_64=("${_pkgreal}-v${pkgver}-1-x64.tar.gz::${url}/releases/download/v${pkgver}-1/bilibili-v${pkgver}-1-x64.tar.gz")
-sha256sums_x86_64=('SKIP')
+sha256sums=('7cf1a17b2a0932927396d5fd6a5c7c5b418222a405cc99322d0a730741f41b89')
+sha256sums_x86_64=('3657b4f5d0d29ad1917a0476d97e07cfee76cfc2532c635566a6025b0297e1c5')
 source=("bilibili.svg::https://raw.githubusercontent.com/wings1848/bilibili-linux/v${pkgver}-1/res/icons/bilibili.svg")
-sha256sums=('SKIP')
+install="${pkgname}.install"
 
 package() {
   cd "${srcdir}"
@@ -66,7 +69,9 @@ DESKTOP
   install -Dm644 "${srcdir}/bilibili.svg" "${pkgdir}/usr/share/icons/hicolor/scalable/apps/bilibili.svg"
 
   # Create wrapper script for /usr/bin/bilibili
-  # Loads user flags, sets Wayland/DE environment, then launches Electron
+  # Auto-detects GPU at runtime and applies matching video decode flags.
+  # User flags from ~/.config/bilibili/bilibili-flags.conf are appended
+  # AFTER defaults — override via Chromium last-wins semantics.
   cat > "${pkgdir}/opt/bilibili/${pkgname}.wrapper" << 'WRAPPER'
 #!/bin/bash
 set -e
@@ -79,11 +84,11 @@ export ELECTRON_DISABLE_SECURITY_WARNINGS=true
 export NODE_ENV=production
 export APPIMAGE=1  # enable update check
 
-# Wayland auto-detect
+# Wayland auto-detect — prefers Wayland when available
 export ELECTRON_OZONE_PLATFORM_HINT="${ELECTRON_OZONE_PLATFORM_HINT:-auto}"
 
-# Correct taskbar icon grouping
-export CHROME_DESKTOP="${pkgname}.desktop"
+# Correct taskbar icon grouping (literal value — heredoc is single-quoted)
+export CHROME_DESKTOP="bilibili-gpu-bin.desktop"
 
 # Trash integration
 case "${XDG_CURRENT_DESKTOP}" in
@@ -92,7 +97,38 @@ case "${XDG_CURRENT_DESKTOP}" in
     XFCE) export ELECTRON_TRASH="gvfs-trash" ;;
 esac
 
-# Load user-defined GPU/flags configuration
+# === GPU acceleration flags ===
+# Common flags — safe and beneficial for all GPUs (Intel/AMD/NVIDIA).
+# No ANGLE override: let Electron use its default GL backend
+# (EGL on Wayland, GLX on X11, D3D11 on Windows).
+declare -a DEFAULT_FLAGS=(
+    --ignore-gpu-blocklist
+    --enable-gpu-rasterization
+    --enable-zero-copy
+    --disable-gpu-sandbox
+)
+
+# Auto-detect GPU vendor and apply matching video decode feature flags.
+# Uses /proc/driver/nvidia (exists iff the NVIDIA kernel module is loaded)
+# — zero extra dependencies, no pciutils needed.
+if [[ -d /proc/driver/nvidia ]]; then
+    # NVIDIA: VA-API → libva-nvidia-driver → NVDEC
+    # Must set LIBVA_DRIVER_NAME or libva won't find the NVIDIA backend
+    export LIBVA_DRIVER_NAME=nvidia
+    DEFAULT_FLAGS+=(
+        --enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,VaapiOnNvidiaGPUs,VaapiIgnoreDriverChecks,PlatformHEVCDecoderSupport
+    )
+else
+    # Intel / AMD / other: standard VA-API path (Mesa Gallium)
+    DEFAULT_FLAGS+=(
+        --enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,VaapiVideoDecoder,VaapiVideoEncoder,VaapiIgnoreDriverChecks,PlatformHEVCDecoderSupport
+    )
+fi
+
+# Load user-defined flags from config file.
+# Appended AFTER defaults — Chromium's last-wins semantics let users
+# override individual flags. --enable-features is cumulative across
+# multiple occurrences, so user features add to (not replace) defaults.
 declare -a flags
 for f in "${XDG_CONFIG_HOME}/bilibili/bilibili-flags.conf" \
          "${XDG_CONFIG_HOME}/bilibili-flags.conf"; do
@@ -113,20 +149,20 @@ if [[ $EUID -eq 0 ]] && [[ "${ELECTRON_RUN_AS_NODE}" != "1" ]]; then
 fi
 
 exec "${root_dir}/electron/electron" "${root_dir}/app/app.asar" \
-  "${flags[@]}" "${_SANDBOX_ARG[@]}" "$@"
+  "${DEFAULT_FLAGS[@]}" "${flags[@]}" "${_SANDBOX_ARG[@]}" "$@"
 WRAPPER
   chmod 755 "${pkgdir}/opt/bilibili/${pkgname}.wrapper"
 
   # Symlink /usr/bin/bilibili → wrapper
   ln -sf "/opt/bilibili/${pkgname}.wrapper" "${pkgdir}/usr/bin/bilibili"
 
-  # Install default flags config for NVIDIA GPU acceleration
+  # Install default flags config template.
+  # GPU-specific video decode flags are auto-detected by the wrapper at runtime;
+  # this file provides only the safe common baseline. Users may add custom flags
+  # here — they are appended after defaults and override via last-wins semantics.
   install -dm755 "${pkgdir}/etc/skel/.config/bilibili"
   cat > "${pkgdir}/etc/skel/.config/bilibili/bilibili-flags.conf" << 'FLAGS'
 --ignore-gpu-blocklist
---use-gl=angle
---use-angle=gl
---enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,VaapiOnNvidiaGPUs,VaapiIgnoreDriverChecks,PlatformHEVCDecoderSupport
 --enable-gpu-rasterization
 --enable-zero-copy
 --disable-gpu-sandbox

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -49,20 +49,31 @@ package() {
   # NOTE: tar.gz has no top-level directory, extracts directly into srcdir
   install -dm755 "${pkgdir}/opt/bilibili" "${pkgdir}/usr/bin"
   cp -r bin app electron "${pkgdir}/opt/bilibili/"
+  # Remove the tarball's launcher script — wrapper replaces it entirely
+  rm -f "${pkgdir}/opt/bilibili/bin/bilibili"
 
   # Install .desktop file (tar.gz doesn't ship one — electron-builder
   # only embeds it in the AppImage, not in the tarball)
   install -dm755 "${pkgdir}/usr/share/applications"
   cat > "${pkgdir}/usr/share/applications/${pkgname}.desktop" << DESKTOP
 [Desktop Entry]
-Name=bilibili
+Name=Bilibili
+Name[zh_CN]=哔哩哔哩
+Name[zh_TW]=嗶哩嗶哩
 Exec=/usr/bin/bilibili %U
 Terminal=false
 Type=Application
 Icon=bilibili
 StartupWMClass=bilibili
-Comment=BiliBili client for Linux (GPU accelerated, Electron 43).
-Categories=AudioVideo;
+Comment=BiliBili client for Linux (GPU accelerated, Electron 43)
+Comment[zh_CN]=哔哩哔哩桌面版
+Comment[zh_TW]=嗶哩嗶哩桌面版
+Categories=AudioVideo;Video;TV;
+Keywords=animation;anime;drama;live;movie;player;tv;video;bilibili;
+Keywords[zh_CN]=B站;播放器;动画;动漫;电影;番剧;视频;直播;
+Keywords[zh_TW]=B站;播放器;動畫;動漫;电影;番劇;視頻;直播;
+StartupNotify=true
+SingleMainWindow=true
 DESKTOP
 
   # Install icon
@@ -82,8 +93,6 @@ export ELECTRON_IS_DEV=0
 export ELECTRON_FORCE_IS_PACKAGED=true
 export ELECTRON_DISABLE_SECURITY_WARNINGS=true
 export NODE_ENV=production
-export APPIMAGE=1  # enable update check
-
 # Wayland auto-detect — prefers Wayland when available
 export ELECTRON_OZONE_PLATFORM_HINT="${ELECTRON_OZONE_PLATFORM_HINT:-auto}"
 
@@ -92,9 +101,9 @@ export CHROME_DESKTOP="bilibili-gpu-bin.desktop"
 
 # Trash integration
 case "${XDG_CURRENT_DESKTOP}" in
-    KDE) export ELECTRON_TRASH="kioclient5" ;;
-    GNOME) export ELECTRON_TRASH="gio" ;;
-    XFCE) export ELECTRON_TRASH="gvfs-trash" ;;
+    *KDE*) export ELECTRON_TRASH="kioclient5" ;;
+    *GNOME*) export ELECTRON_TRASH="gio" ;;
+    *XFCE*) export ELECTRON_TRASH="gvfs-trash" ;;
 esac
 
 # === GPU acceleration flags ===
@@ -129,8 +138,11 @@ fi
 # Appended AFTER defaults — Chromium's last-wins semantics let users
 # override individual flags. --enable-features is cumulative across
 # multiple occurrences, so user features add to (not replace) defaults.
+# Search order: app's userData path (matches electron-tool.ts) →
+# legacy path → flat fallback.
 declare -a flags
-for f in "${XDG_CONFIG_HOME}/bilibili/bilibili-flags.conf" \
+for f in "${XDG_CONFIG_HOME}/bilibili-linux/bilibili-flags.conf" \
+         "${XDG_CONFIG_HOME}/bilibili/bilibili-flags.conf" \
          "${XDG_CONFIG_HOME}/bilibili-flags.conf"; do
   if [[ -f "$f" ]]; then
     while IFS= read -r line; do
@@ -141,6 +153,17 @@ for f in "${XDG_CONFIG_HOME}/bilibili/bilibili-flags.conf" \
     done < "$f"
   fi
 done
+
+# Strip known-harmful flags that linger in old configs (pkgrel ≤7).
+# --use-gl=angle / --use-angle=gl break VA-API on Intel/AMD Wayland
+# and are no longer needed on any platform with Electron 43+.
+for i in "${!flags[@]}"; do
+  case "${flags[$i]}" in
+    --use-gl=angle|--use-angle=gl|--use-gl|--use-angle)
+      unset 'flags[$i]' ;;
+  esac
+done
+flags=("${flags[@]}")
 
 # --no-sandbox when running as root
 _SANDBOX_ARG=()
@@ -156,12 +179,13 @@ WRAPPER
   # Symlink /usr/bin/bilibili → wrapper
   ln -sf "/opt/bilibili/${pkgname}.wrapper" "${pkgdir}/usr/bin/bilibili"
 
-  # Install default flags config template.
+  # Install default flags config template to the app's userData directory
+  # (matches package.json "name": "bilibili-linux" → ~/.config/bilibili-linux/)
   # GPU-specific video decode flags are auto-detected by the wrapper at runtime;
   # this file provides only the safe common baseline. Users may add custom flags
   # here — they are appended after defaults and override via last-wins semantics.
-  install -dm755 "${pkgdir}/etc/skel/.config/bilibili"
-  cat > "${pkgdir}/etc/skel/.config/bilibili/bilibili-flags.conf" << 'FLAGS'
+  install -dm755 "${pkgdir}/etc/skel/.config/bilibili-linux"
+  cat > "${pkgdir}/etc/skel/.config/bilibili-linux/bilibili-flags.conf" << 'FLAGS'
 --ignore-gpu-blocklist
 --enable-gpu-rasterization
 --enable-zero-copy

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,0 +1,72 @@
+# Maintainer: Your Name <your@email>
+# Contributor: msojocs <jiyecafe@gmail.com>
+#
+# NVIDIA GPU acceleration fork — Electron 43 (Chromium 150) + VaapiOnNvidiaGPUs
+# for NVDEC hardware video decode on NVIDIA GPUs under Wayland.
+# Original upstream: https://github.com/msojocs/bilibili-linux
+# Fork: https://github.com/wings1848/bilibili-linux
+
+pkgname=bilibili-linux-gpu
+_pkgreal=bilibili
+pkgver=1.17.9
+pkgrel=1
+pkgdesc="Bilibili client for Linux (Electron 43, NVIDIA GPU acceleration fork)"
+arch=('x86_64')
+url="https://github.com/wings1848/bilibili-linux"
+license=('MIT')
+depends=(
+  'gtk3'
+  'libnotify'
+  'libxss'
+  'nss'
+  'libva'
+  'libva-nvidia-driver'
+  'libxtst'
+  'xdg-utils'
+  'at-spi2-core'
+  'cups'
+  'dbus'
+  'libxkbcommon'
+  'mesa'
+  'alsa-lib'
+)
+optdepends=(
+  'python-faster-whisper: AI subtitle transcription'
+)
+conflicts=('bilibili' 'bilibili-bin')
+provides=("${_pkgreal}=${pkgver}")
+source_x86_64=("${pkgname}-${pkgver}.AppImage::${url}/releases/download/v${pkgver}-${pkgrel}/${_pkgreal}-${pkgver}-${pkgrel}-x86_64.AppImage")
+sha256sums_x86_64=('SKIP')
+prepare() {
+  cd "${srcdir}"
+  chmod +x "${pkgname}-${pkgver}.AppImage"
+  # Extract AppImage to get app.asar + electron binary
+  "${pkgname}-${pkgver}.AppImage" --appimage-extract 2>/dev/null || true
+}
+package() {
+  if [ -d "${srcdir}/squashfs-root" ]; then
+    # Installed from AppImage extraction
+    install -d "${pkgdir}/opt/bilibili"
+    cp -r "${srcdir}/squashfs-root"/* "${pkgdir}/opt/bilibili/"
+    ln -sf "/opt/bilibili/AppRun" "${pkgdir}/usr/bin/bilibili"
+  else
+    # Fallback: download and install app.asar + electron from tarball release
+    install -d "${pkgdir}/opt/bilibili/app"
+    install -d "${pkgdir}/opt/bilibili/electron"
+    echo "Please download and extract bilibili-${pkgver}-${pkgrel}-x64.tar.gz from GitHub Releases"
+    echo "See: ${url}/releases/tag/v${pkgver}-${pkgrel}"
+  fi
+  # Install flags config for NVIDIA GPU acceleration
+  install -dm755 "${pkgdir}/etc/skel/.config/bilibili"
+  cat > "${pkgdir}/etc/skel/.config/bilibili/bilibili-flags.conf" << 'FLAGS'
+# bilibili GPU/VA-API flags - NVIDIA + Wayland
+# https://github.com/wings1848/bilibili-linux#gpu-acceleration-configuration
+--ignore-gpu-blocklist
+--use-gl=angle
+--use-angle=gl
+--enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,VaapiOnNvidiaGPUs,VaapiIgnoreDriverChecks,PlatformHEVCDecoderSupport
+--enable-gpu-rasterization
+--enable-zero-copy
+--disable-gpu-sandbox
+FLAGS
+}

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainer: Your Name <your@email>
+# Maintainer: wingsbutterfly <wingsbutterfly@users.noreply.github.com>
 # Contributor: msojocs <jiyecafe@gmail.com>
 #
 # NVIDIA GPU acceleration fork — Electron 43 (Chromium 150) + VaapiOnNvidiaGPUs
@@ -6,7 +6,7 @@
 # Original upstream: https://github.com/msojocs/bilibili-linux
 # Fork: https://github.com/wings1848/bilibili-linux
 
-pkgname=bilibili-linux-gpu
+pkgname=bilibili-gpu-bin
 _pkgreal=bilibili
 pkgver=1.17.9
 pkgrel=1
@@ -17,7 +17,6 @@ license=('MIT')
 depends=(
   'gtk3'
   'libnotify'
-  'libxss'
   'nss'
   'libva'
   'libva-nvidia-driver'
@@ -25,7 +24,6 @@ depends=(
   'xdg-utils'
   'at-spi2-core'
   'cups'
-  'dbus'
   'libxkbcommon'
   'mesa'
   'alsa-lib'
@@ -35,32 +33,20 @@ optdepends=(
 )
 conflicts=('bilibili' 'bilibili-bin')
 provides=("${_pkgreal}=${pkgver}")
-source_x86_64=("${pkgname}-${pkgver}.AppImage::${url}/releases/download/v${pkgver}-${pkgrel}/${_pkgreal}-${pkgver}-${pkgrel}-x86_64.AppImage")
+source_x86_64=("${_pkgreal}-${pkgver}-x86_64.AppImage::${url}/releases/download/v${pkgver}-${pkgrel}/bilibili-${pkgver}-x86_64.AppImage")
 sha256sums_x86_64=('SKIP')
-prepare() {
-  cd "${srcdir}"
-  chmod +x "${pkgname}-${pkgver}.AppImage"
-  # Extract AppImage to get app.asar + electron binary
-  "${pkgname}-${pkgver}.AppImage" --appimage-extract 2>/dev/null || true
-}
+
 package() {
-  if [ -d "${srcdir}/squashfs-root" ]; then
-    # Installed from AppImage extraction
-    install -d "${pkgdir}/opt/bilibili"
-    cp -r "${srcdir}/squashfs-root"/* "${pkgdir}/opt/bilibili/"
-    ln -sf "/opt/bilibili/AppRun" "${pkgdir}/usr/bin/bilibili"
-  else
-    # Fallback: download and install app.asar + electron from tarball release
-    install -d "${pkgdir}/opt/bilibili/app"
-    install -d "${pkgdir}/opt/bilibili/electron"
-    echo "Please download and extract bilibili-${pkgver}-${pkgrel}-x64.tar.gz from GitHub Releases"
-    echo "See: ${url}/releases/tag/v${pkgver}-${pkgrel}"
-  fi
-  # Install flags config for NVIDIA GPU acceleration
+  install -dm755 "${pkgdir}/opt/bilibili"
+  install -dm755 "${pkgdir}/usr/bin"
+  # Extract and install from AppImage
+  "${srcdir}/bilibili-${pkgver}-x86_64.AppImage" --appimage-extract
+  cp -r squashfs-root/* "${pkgdir}/opt/bilibili/"
+  ln -sf "/opt/bilibili/AppRun" "${pkgdir}/usr/bin/bilibili"
+
+  # Install default flags config for NVIDIA GPU acceleration
   install -dm755 "${pkgdir}/etc/skel/.config/bilibili"
   cat > "${pkgdir}/etc/skel/.config/bilibili/bilibili-flags.conf" << 'FLAGS'
-# bilibili GPU/VA-API flags - NVIDIA + Wayland
-# https://github.com/wings1848/bilibili-linux#gpu-acceleration-configuration
 --ignore-gpu-blocklist
 --use-gl=angle
 --use-angle=gl

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -9,7 +9,7 @@
 pkgname=bilibili-gpu-bin
 _pkgreal=bilibili
 pkgver=1.17.9
-pkgrel=1
+pkgrel=7
 pkgdesc="Bilibili client for Linux (Electron 43, NVIDIA GPU acceleration fork)"
 arch=('x86_64')
 url="https://github.com/wings1848/bilibili-linux"
@@ -33,16 +33,92 @@ optdepends=(
 )
 conflicts=('bilibili' 'bilibili-bin')
 provides=("${_pkgreal}=${pkgver}")
-source_x86_64=("${_pkgreal}-${pkgver}-x86_64.AppImage::${url}/releases/download/v${pkgver}-${pkgrel}/bilibili-${pkgver}-x86_64.AppImage")
+source_x86_64=("${_pkgreal}-v${pkgver}-1-x64.tar.gz::${url}/releases/download/v${pkgver}-1/bilibili-v${pkgver}-1-x64.tar.gz")
 sha256sums_x86_64=('SKIP')
+source=("bilibili.svg::https://raw.githubusercontent.com/wings1848/bilibili-linux/v${pkgver}-1/res/icons/bilibili.svg")
+sha256sums=('SKIP')
 
 package() {
-  install -dm755 "${pkgdir}/opt/bilibili"
-  install -dm755 "${pkgdir}/usr/bin"
-  # Extract and install from AppImage
-  "${srcdir}/bilibili-${pkgver}-x86_64.AppImage" --appimage-extract
-  cp -r squashfs-root/* "${pkgdir}/opt/bilibili/"
-  ln -sf "/opt/bilibili/AppRun" "${pkgdir}/usr/bin/bilibili"
+  cd "${srcdir}"
+
+  # Extract the pre-built release tarball
+  # Structure: bin/bilibili (launcher), app/ (app.asar), electron/ (Electron 43 runtime)
+  # NOTE: tar.gz has no top-level directory, extracts directly into srcdir
+  install -dm755 "${pkgdir}/opt/bilibili" "${pkgdir}/usr/bin"
+  cp -r bin app electron "${pkgdir}/opt/bilibili/"
+
+  # Install .desktop file (tar.gz doesn't ship one — electron-builder
+  # only embeds it in the AppImage, not in the tarball)
+  install -dm755 "${pkgdir}/usr/share/applications"
+  cat > "${pkgdir}/usr/share/applications/${pkgname}.desktop" << DESKTOP
+[Desktop Entry]
+Name=bilibili
+Exec=/usr/bin/bilibili %U
+Terminal=false
+Type=Application
+Icon=bilibili
+StartupWMClass=bilibili
+Comment=BiliBili client for Linux (GPU accelerated, Electron 43).
+Categories=AudioVideo;
+DESKTOP
+
+  # Install icon
+  install -Dm644 "${srcdir}/bilibili.svg" "${pkgdir}/usr/share/icons/hicolor/scalable/apps/bilibili.svg"
+
+  # Create wrapper script for /usr/bin/bilibili
+  # Loads user flags, sets Wayland/DE environment, then launches Electron
+  cat > "${pkgdir}/opt/bilibili/${pkgname}.wrapper" << 'WRAPPER'
+#!/bin/bash
+set -e
+root_dir="/opt/bilibili"
+XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+
+export ELECTRON_IS_DEV=0
+export ELECTRON_FORCE_IS_PACKAGED=true
+export ELECTRON_DISABLE_SECURITY_WARNINGS=true
+export NODE_ENV=production
+export APPIMAGE=1  # enable update check
+
+# Wayland auto-detect
+export ELECTRON_OZONE_PLATFORM_HINT="${ELECTRON_OZONE_PLATFORM_HINT:-auto}"
+
+# Correct taskbar icon grouping
+export CHROME_DESKTOP="${pkgname}.desktop"
+
+# Trash integration
+case "${XDG_CURRENT_DESKTOP}" in
+    KDE) export ELECTRON_TRASH="kioclient5" ;;
+    GNOME) export ELECTRON_TRASH="gio" ;;
+    XFCE) export ELECTRON_TRASH="gvfs-trash" ;;
+esac
+
+# Load user-defined GPU/flags configuration
+declare -a flags
+for f in "${XDG_CONFIG_HOME}/bilibili/bilibili-flags.conf" \
+         "${XDG_CONFIG_HOME}/bilibili-flags.conf"; do
+  if [[ -f "$f" ]]; then
+    while IFS= read -r line; do
+      [[ "$line" =~ ^[[:space:]]*# ]] || [[ -z "$line" ]] || {
+        read -ra parts <<< "$line"
+        flags+=("${parts[@]}")
+      }
+    done < "$f"
+  fi
+done
+
+# --no-sandbox when running as root
+_SANDBOX_ARG=()
+if [[ $EUID -eq 0 ]] && [[ "${ELECTRON_RUN_AS_NODE}" != "1" ]]; then
+  _SANDBOX_ARG=("--no-sandbox")
+fi
+
+exec "${root_dir}/electron/electron" "${root_dir}/app/app.asar" \
+  "${flags[@]}" "${_SANDBOX_ARG[@]}" "$@"
+WRAPPER
+  chmod 755 "${pkgdir}/opt/bilibili/${pkgname}.wrapper"
+
+  # Symlink /usr/bin/bilibili → wrapper
+  ln -sf "/opt/bilibili/${pkgname}.wrapper" "${pkgdir}/usr/bin/bilibili"
 
   # Install default flags config for NVIDIA GPU acceleration
   install -dm755 "${pkgdir}/etc/skel/.config/bilibili"

--- a/aur/bilibili-gpu-bin.install
+++ b/aur/bilibili-gpu-bin.install
@@ -7,7 +7,8 @@ post_install() {
     Intel / AMD GPU  → VA-API path (VaapiVideoDecoder, Mesa Gallium)
     No GPU-specific configuration needed — the wrapper adapts automatically.
 
-    Custom flags:  ~/.config/bilibili/bilibili-flags.conf
+    Custom flags:  ~/.config/bilibili-linux/bilibili-flags.conf
+    (also checked: ~/.config/bilibili/bilibili-flags.conf)
     Appended after defaults; Chromium last-wins semantics for overrides.
     Verify:        play a video, then check GPU decode with:
                      cat /proc/$(pgrep -f "type=gpu-process.*bilibili")/fdinfo/* | grep drm-engine-video
@@ -19,15 +20,15 @@ MSG
 
 post_upgrade() {
     cat << 'MSG'
-==> bilibili-gpu-bin: GPU acceleration flags updated (pkgrel 8)
+==> bilibili-gpu-bin: GPU acceleration auto-detection updated
     GPU video decode flags are now auto-detected at runtime:
       - /proc/driver/nvidia present → NVIDIA NVDEC path
-      - otherwise                       → Intel/AMD VA-API path
+      - otherwise                     → Intel/AMD VA-API path
 
-    If you previously customized ~/.config/bilibili/bilibili-flags.conf,
-    your custom flags are still loaded and appended after the defaults.
-    You may want to remove old NVIDIA-only flags (--use-gl=angle,
-    --use-angle=gl, VaapiOnNvidiaGPUs) if you are on Intel/AMD hardware.
+    Old flags (--use-gl=angle, --use-angle=gl) are automatically
+    filtered from your config at runtime — no manual cleanup needed.
+    Config location: ~/.config/bilibili-linux/bilibili-flags.conf
+    Custom flags are appended after defaults and can override them.
 MSG
 }
 

--- a/aur/bilibili-gpu-bin.install
+++ b/aur/bilibili-gpu-bin.install
@@ -1,0 +1,40 @@
+# bilibili-gpu-bin install hooks
+
+post_install() {
+    cat << 'MSG'
+==> bilibili-gpu-bin: GPU acceleration auto-detected at runtime
+    NVIDIA GPU detected → NVDEC path (VaapiOnNvidiaGPUs, libva-nvidia-driver)
+    Intel / AMD GPU  → VA-API path (VaapiVideoDecoder, Mesa Gallium)
+    No GPU-specific configuration needed — the wrapper adapts automatically.
+
+    Custom flags:  ~/.config/bilibili/bilibili-flags.conf
+    Appended after defaults; Chromium last-wins semantics for overrides.
+    Verify:        play a video, then check GPU decode with:
+                     cat /proc/$(pgrep -f "type=gpu-process.*bilibili")/fdinfo/* | grep drm-engine-video
+
+    For NVIDIA GPU: libva-nvidia-driver (extra repo) is required for NVDEC path.
+    Install it manually if you skipped the optional dependency.
+MSG
+}
+
+post_upgrade() {
+    cat << 'MSG'
+==> bilibili-gpu-bin: GPU acceleration flags updated (pkgrel 8)
+    GPU video decode flags are now auto-detected at runtime:
+      - /proc/driver/nvidia present → NVIDIA NVDEC path
+      - otherwise                       → Intel/AMD VA-API path
+
+    If you previously customized ~/.config/bilibili/bilibili-flags.conf,
+    your custom flags are still loaded and appended after the defaults.
+    You may want to remove old NVIDIA-only flags (--use-gl=angle,
+    --use-angle=gl, VaapiOnNvidiaGPUs) if you are on Intel/AMD hardware.
+MSG
+}
+
+pre_remove() {
+    :
+}
+
+post_remove() {
+    :
+}

--- a/conf/build.json
+++ b/conf/build.json
@@ -27,7 +27,7 @@
       "to": "transcribe.py"
     }
   ],
-  "electronVersion": "28.2.1",
+  "electronVersion": "43.1.1",
   "appId": "com.bilibili.app",
   "mac": {
     "target": [

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "app-builder-lib": "24.13.3",
     "builder-util": "24.13.1",
     "chrome-remote-interface": "^0.33.3",
-    "electron": "^37.3.1",
+    "electron": "^43.1.1",
     "electron-builder": "^24.13.3",
     "eslint": "^9.33.0",
     "eslint-plugin-perfectionist": "^4.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: ^0.33.3
         version: 0.33.3
       electron:
-        specifier: ^37.3.1
-        version: 37.10.3
+        specifier: ^43.1.1
+        version: 43.2.0
       electron-builder:
         specifier: ^24.13.3
         version: 24.13.3(electron-builder-squirrel-windows@24.13.3)
@@ -236,14 +236,18 @@ packages:
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
     engines: {node: '>= 8.9.0'}
 
+  '@electron-internal/extract-zip@1.0.4':
+    resolution: {integrity: sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==}
+    engines: {node: '>=22.12.0'}
+
   '@electron/asar@3.4.1':
     resolution: {integrity: sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==}
     engines: {node: '>=10.12.0'}
     hasBin: true
 
-  '@electron/get@2.0.3':
-    resolution: {integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==}
-    engines: {node: '>=12'}
+  '@electron/get@5.0.0':
+    resolution: {integrity: sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==}
+    engines: {node: '>=22.12.0'}
 
   '@electron/notarize@2.2.1':
     resolution: {integrity: sha512-aL+bFMIkpR0cmmj5Zgy0LMKEpgy43/hw5zadEArgmAMWWlKc5buwFvFT9G/o/YJkvXAJm5q3iuTuLaiaXW39sg==}
@@ -886,10 +890,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@sindresorhus/is@4.6.0':
-    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
-    engines: {node: '>=10'}
-
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
@@ -975,16 +975,9 @@ packages:
   '@swc/types@0.1.25':
     resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
 
-  '@szmarczak/http-timer@4.0.6':
-    resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
-    engines: {node: '>=10'}
-
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
-
-  '@types/cacheable-request@6.0.3':
-    resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
   '@types/chrome@0.1.32':
     resolution: {integrity: sha512-n5Cqlh7zyAqRLQWLXkeV5K/1BgDZdVcO/dJSTa8x+7w+sx7m73UrDmduAptg4KorMtyTW2TNnPu8RGeaDMKNGg==}
@@ -1007,23 +1000,14 @@ packages:
   '@types/har-format@1.2.16':
     resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
-  '@types/http-cache-semantics@4.0.4':
-    resolution: {integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==}
-
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-
-  '@types/keyv@3.1.4':
-    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
   '@types/md5@2.3.6':
     resolution: {integrity: sha512-WD69gNXtRBnpknfZcb4TRQ0XJQbUPZcai/Qdhmka3sxUR3Et8NrXoeAoknG/LghYHTf4ve795rInVYHBTQdNVA==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
-
-  '@types/node@22.19.3':
-    resolution: {integrity: sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==}
 
   '@types/node@24.10.4':
     resolution: {integrity: sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==}
@@ -1042,17 +1026,11 @@ packages:
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
 
-  '@types/responselike@1.0.3':
-    resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
-
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/verror@1.10.11':
     resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
-
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@typescript-eslint/eslint-plugin@8.49.0':
     resolution: {integrity: sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A==}
@@ -1259,10 +1237,6 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
-  boolean@3.2.0:
-    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -1295,14 +1269,6 @@ packages:
 
   builder-util@24.13.1:
     resolution: {integrity: sha512-NhbCSIntruNDTOVI9fdXz0dihaqX2YuE1D6zZMrwiErzH4ELZHE6mdiB40wEgZNprDia+FghRFgKoAqMZRRjSA==}
-
-  cacheable-lookup@5.0.4:
-    resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
-    engines: {node: '>=10.6.0'}
-
-  cacheable-request@7.0.4:
-    resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
-    engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -1348,9 +1314,6 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
-
-  clone-response@1.0.3:
-    resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1440,24 +1403,8 @@ packages:
       supports-color:
         optional: true
 
-  decompress-response@6.0.0:
-    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
-    engines: {node: '>=10'}
-
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-
-  defer-to-connect@2.0.1:
-    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
-    engines: {node: '>=10'}
-
-  define-data-property@1.1.4:
-    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
-    engines: {node: '>= 0.4'}
-
-  define-properties@1.2.1:
-    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
-    engines: {node: '>= 0.4'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -1467,9 +1414,6 @@ packages:
     resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
     engines: {node: '>=0.10'}
     hasBin: true
-
-  detect-node@2.1.0:
-    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
 
   dir-compare@3.3.0:
     resolution: {integrity: sha512-J7/et3WlGUCxjdnD3HAAzQ6nsnc0WL6DD7WcwJb7c39iH1+AWfg+9OqzJNaI6PkBwBvm1mhZNL9iY/nRiZXlPg==}
@@ -1513,9 +1457,9 @@ packages:
   electron-publish@24.13.1:
     resolution: {integrity: sha512-2ZgdEqJ8e9D17Hwp5LEq5mLQPjqU3lv/IALvgp+4W8VeNhryfGhYEQC/PgDPMrnWUp+l60Ou5SJLsu+k4mhQ8A==}
 
-  electron@37.10.3:
-    resolution: {integrity: sha512-3IjCGSjQmH50IbW2PFveaTzK+KwcFX9PEhE7KXb9v5IT8cLAiryAN7qezm/XzODhDRlLu0xKG1j8xWBtZ/bx/g==}
-    engines: {node: '>= 12.20.55'}
+  electron@43.2.0:
+    resolution: {integrity: sha512-80zvrgG7ZRXD+tD0IyLvrnN9n+veSxadMRsMaC9wKKP3iUbtC7rGM8+dVuCmOb0Rrwwv8ESW4awnUZh9Hbp1fA==}
+    engines: {node: '>= 22.12.0'}
     hasBin: true
 
   emoji-regex@8.0.0:
@@ -1527,9 +1471,9 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  env-paths@2.2.1:
-    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
-    engines: {node: '>=6'}
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
@@ -1552,9 +1496,6 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
-
-  es6-error@4.1.1:
-    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -1628,11 +1569,6 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
-
   extsprintf@1.4.1:
     resolution: {integrity: sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==}
     engines: {'0': node >=0.6.0}
@@ -1645,9 +1581,6 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1698,10 +1631,6 @@ packages:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
 
-  fs-extra@8.1.0:
-    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
-    engines: {node: '>=6 <7 || >=8'}
-
   fs-extra@9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
@@ -1733,10 +1662,6 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
-
   get-xpath@3.3.0:
     resolution: {integrity: sha512-AKbHVEHSlSDS9AJDmjfSxV010xSVRFzkS4UkGCb8CaGvorp83GCuKwcmzF/64CVp3M5wjgy9tc6y1uR2V+c5Xw==}
 
@@ -1752,10 +1677,6 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
 
-  global-agent@3.0.0:
-    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
-    engines: {node: '>=10.0'}
-
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -1764,17 +1685,9 @@ packages:
     resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
     engines: {node: '>=18'}
 
-  globalthis@1.0.4:
-    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
-    engines: {node: '>= 0.4'}
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
-
-  got@11.8.6:
-    resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
-    engines: {node: '>=10.19.0'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1782,9 +1695,6 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-
-  has-property-descriptors@1.0.2:
-    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -1808,16 +1718,9 @@ packages:
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
 
-  http-cache-semantics@4.2.0:
-    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
-
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
-
-  http2-wrapper@1.0.3:
-    resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
-    engines: {node: '>=10.19.0'}
 
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -1948,9 +1851,6 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
-  json-stringify-safe@5.0.1:
-    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
-
   json2mq@0.2.0:
     resolution: {integrity: sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==}
 
@@ -1958,9 +1858,6 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
-
-  jsonfile@4.0.0:
-    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
@@ -2013,19 +1910,11 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
-  lowercase-keys@2.0.0:
-    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
-    engines: {node: '>=8'}
-
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
-    engines: {node: '>=10'}
-
-  matcher@3.0.0:
-    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
     engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
@@ -2055,14 +1944,6 @@ packages:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
     engines: {node: '>=4.0.0'}
     hasBin: true
-
-  mimic-response@1.0.1:
-    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
-    engines: {node: '>=4'}
-
-  mimic-response@3.1.0:
-    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
-    engines: {node: '>=10'}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -2124,24 +2005,12 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
-  normalize-url@6.1.0:
-    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
-    engines: {node: '>=10'}
-
-  object-keys@1.1.1:
-    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
-    engines: {node: '>= 0.4'}
-
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
-
-  p-cancelable@2.1.1:
-    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
-    engines: {node: '>=8'}
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -2184,9 +2053,6 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
-
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2231,19 +2097,12 @@ packages:
     engines: {node: '>=20.0.0'}
     hasBin: true
 
-  pump@3.0.3:
-    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   pure-conditions@1.2.3:
     resolution: {integrity: sha512-TlBrX7PHkaglbE9eYYnc2Zk10PZ9wWllVjY33PQDp1/LK3aGC81RFKr0QzLwiKfipJlZZAK197c9YQFO6BAOFw==}
-
-  quick-lru@5.1.1:
-    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
-    engines: {node: '>=10'}
 
   rc-cascader@3.34.0:
     resolution: {integrity: sha512-KpXypcvju9ptjW9FaN2NFcA2QH9E9LHKq169Y0eWtH4e/wHQ5Wh5qZakAgvb8EKZ736WZ3B0zLLOBsrsja5Dag==}
@@ -2552,9 +2411,6 @@ packages:
   resize-observer-polyfill@1.5.1:
     resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
 
-  resolve-alpn@1.2.1:
-    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
-
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2564,16 +2420,9 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  responselike@2.0.1:
-    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
-
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
-
-  roarr@2.15.4:
-    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
-    engines: {node: '>=8.0'}
 
   rollup@4.53.3:
     resolution: {integrity: sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==}
@@ -2726,21 +2575,10 @@ packages:
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
-  semver-compare@1.0.0:
-    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
-
-  semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
     hasBin: true
-
-  serialize-error@7.0.1:
-    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
-    engines: {node: '>=10'}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2784,9 +2622,6 @@ packages:
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
-
-  sprintf-js@1.1.3:
-    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
@@ -2900,10 +2735,6 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  type-fest@0.13.1:
-    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
-    engines: {node: '>=10'}
-
   typescript-eslint@8.49.0:
     resolution: {integrity: sha512-zRSVH1WXD0uXczCXw+nsdjGPUdx4dfrs5VQoHnUWmv1U3oNlAKv4FUNdLDhVUg+gYn+a5hUESqch//Rv5wVhrg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2926,15 +2757,12 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  universalify@0.1.2:
-    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
-    engines: {node: '>= 4.0.0'}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -3064,9 +2892,6 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
-
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -3200,23 +3025,24 @@ snapshots:
       ajv: 6.12.6
       ajv-keywords: 3.5.2(ajv@6.12.6)
 
+  '@electron-internal/extract-zip@1.0.4': {}
+
   '@electron/asar@3.4.1':
     dependencies:
       commander: 5.1.0
       glob: 7.2.3
       minimatch: 3.1.2
 
-  '@electron/get@2.0.3':
+  '@electron/get@5.0.0':
     dependencies:
       debug: 4.4.3
-      env-paths: 2.2.1
-      fs-extra: 8.1.0
-      got: 11.8.6
+      env-paths: 3.0.0
+      graceful-fs: 4.2.11
       progress: 2.0.3
-      semver: 6.3.1
+      semver: 7.7.3
       sumchecker: 3.0.1
     optionalDependencies:
-      global-agent: 3.0.0
+      undici: 7.28.0
     transitivePeerDependencies:
       - supports-color
 
@@ -3773,8 +3599,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.53.3':
     optional: true
 
-  '@sindresorhus/is@4.6.0': {}
-
   '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -3831,18 +3655,7 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@szmarczak/http-timer@4.0.6':
-    dependencies:
-      defer-to-connect: 2.0.1
-
   '@tootallnate/once@2.0.0': {}
-
-  '@types/cacheable-request@6.0.3':
-    dependencies:
-      '@types/http-cache-semantics': 4.0.4
-      '@types/keyv': 3.1.4
-      '@types/node': 24.10.4
-      '@types/responselike': 1.0.3
 
   '@types/chrome@0.1.32':
     dependencies:
@@ -3867,21 +3680,11 @@ snapshots:
 
   '@types/har-format@1.2.16': {}
 
-  '@types/http-cache-semantics@4.0.4': {}
-
   '@types/json-schema@7.0.15': {}
-
-  '@types/keyv@3.1.4':
-    dependencies:
-      '@types/node': 24.10.4
 
   '@types/md5@2.3.6': {}
 
   '@types/ms@2.1.0': {}
-
-  '@types/node@22.19.3':
-    dependencies:
-      undici-types: 6.21.0
 
   '@types/node@24.10.4':
     dependencies:
@@ -3903,18 +3706,9 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@types/responselike@1.0.3':
-    dependencies:
-      '@types/node': 24.10.4
-
   '@types/use-sync-external-store@0.0.6': {}
 
   '@types/verror@1.10.11':
-    optional: true
-
-  '@types/yauzl@2.10.3':
-    dependencies:
-      '@types/node': 24.10.4
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.2)(typescript@5.8.3))(eslint@9.39.2)(typescript@5.8.3)':
@@ -4260,9 +4054,6 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  boolean@3.2.0:
-    optional: true
-
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -4318,18 +4109,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  cacheable-lookup@5.0.4: {}
-
-  cacheable-request@7.0.4:
-    dependencies:
-      clone-response: 1.0.3
-      get-stream: 5.2.0
-      http-cache-semantics: 4.2.0
-      keyv: 4.5.4
-      lowercase-keys: 2.0.0
-      normalize-url: 6.1.0
-      responselike: 2.0.1
-
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -4376,10 +4155,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
-
-  clone-response@1.0.3:
-    dependencies:
-      mimic-response: 1.0.1
 
   color-convert@2.0.1:
     dependencies:
@@ -4462,34 +4237,11 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  decompress-response@6.0.0:
-    dependencies:
-      mimic-response: 3.1.0
-
   deep-is@0.1.4: {}
-
-  defer-to-connect@2.0.1: {}
-
-  define-data-property@1.1.4:
-    dependencies:
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      gopd: 1.2.0
-    optional: true
-
-  define-properties@1.2.1:
-    dependencies:
-      define-data-property: 1.1.4
-      has-property-descriptors: 1.0.2
-      object-keys: 1.1.1
-    optional: true
 
   delayed-stream@1.0.0: {}
 
   detect-libc@1.0.3:
-    optional: true
-
-  detect-node@2.1.0:
     optional: true
 
   dir-compare@3.3.0:
@@ -4578,11 +4330,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@37.10.3:
+  electron@43.2.0:
     dependencies:
-      '@electron/get': 2.0.3
-      '@types/node': 22.19.3
-      extract-zip: 2.0.1
+      '@electron-internal/extract-zip': 1.0.4
+      '@electron/get': 5.0.0
+      '@types/node': 24.10.4
     transitivePeerDependencies:
       - supports-color
 
@@ -4594,7 +4346,7 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  env-paths@2.2.1: {}
+  env-paths@3.0.0: {}
 
   err-code@2.0.3: {}
 
@@ -4616,9 +4368,6 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
-
-  es6-error@4.1.1:
-    optional: true
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -4737,16 +4486,6 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.4.3
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
-
   extsprintf@1.4.1:
     optional: true
 
@@ -4755,10 +4494,6 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -4812,12 +4547,6 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
-  fs-extra@8.1.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 4.0.0
-      universalify: 0.1.2
-
   fs-extra@9.1.0:
     dependencies:
       at-least-node: 1.0.0
@@ -4856,10 +4585,6 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
-  get-stream@5.2.0:
-    dependencies:
-      pump: 3.0.3
-
   get-xpath@3.3.0: {}
 
   glob-parent@6.0.2:
@@ -4884,50 +4609,15 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
-  global-agent@3.0.0:
-    dependencies:
-      boolean: 3.2.0
-      es6-error: 4.1.1
-      matcher: 3.0.0
-      roarr: 2.15.4
-      semver: 7.7.3
-      serialize-error: 7.0.1
-    optional: true
-
   globals@14.0.0: {}
 
   globals@16.5.0: {}
 
-  globalthis@1.0.4:
-    dependencies:
-      define-properties: 1.2.1
-      gopd: 1.2.0
-    optional: true
-
   gopd@1.2.0: {}
-
-  got@11.8.6:
-    dependencies:
-      '@sindresorhus/is': 4.6.0
-      '@szmarczak/http-timer': 4.0.6
-      '@types/cacheable-request': 6.0.3
-      '@types/responselike': 1.0.3
-      cacheable-lookup: 5.0.4
-      cacheable-request: 7.0.4
-      decompress-response: 6.0.0
-      http2-wrapper: 1.0.3
-      lowercase-keys: 2.0.0
-      p-cancelable: 2.1.1
-      responselike: 2.0.1
 
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
-
-  has-property-descriptors@1.0.2:
-    dependencies:
-      es-define-property: 1.0.1
-    optional: true
 
   has-symbols@1.1.0: {}
 
@@ -4951,8 +4641,6 @@ snapshots:
     dependencies:
       void-elements: 3.1.0
 
-  http-cache-semantics@4.2.0: {}
-
   http-proxy-agent@5.0.0:
     dependencies:
       '@tootallnate/once': 2.0.0
@@ -4960,11 +4648,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  http2-wrapper@1.0.3:
-    dependencies:
-      quick-lru: 5.1.1
-      resolve-alpn: 1.2.1
 
   https-proxy-agent@5.0.1:
     dependencies:
@@ -5072,18 +4755,11 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  json-stringify-safe@5.0.1:
-    optional: true
-
   json2mq@0.2.0:
     dependencies:
       string-convert: 0.2.1
 
   json5@2.2.3: {}
-
-  jsonfile@4.0.0:
-    optionalDependencies:
-      graceful-fs: 4.2.11
 
   jsonfile@6.2.0:
     dependencies:
@@ -5130,18 +4806,11 @@ snapshots:
 
   long@5.3.2: {}
 
-  lowercase-keys@2.0.0: {}
-
   lru-cache@10.4.3: {}
 
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
-
-  matcher@3.0.0:
-    dependencies:
-      escape-string-regexp: 4.0.0
-    optional: true
 
   math-intrinsics@1.1.0: {}
 
@@ -5166,10 +4835,6 @@ snapshots:
       mime-db: 1.52.0
 
   mime@2.6.0: {}
-
-  mimic-response@1.0.1: {}
-
-  mimic-response@3.1.0: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -5216,11 +4881,6 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
-  normalize-url@6.1.0: {}
-
-  object-keys@1.1.1:
-    optional: true
-
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -5233,8 +4893,6 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
-
-  p-cancelable@2.1.1: {}
 
   p-limit@3.1.0:
     dependencies:
@@ -5271,8 +4929,6 @@ snapshots:
       minipass: 7.1.2
 
   path-type@4.0.0: {}
-
-  pend@1.2.0: {}
 
   picocolors@1.1.1: {}
 
@@ -5321,16 +4977,9 @@ snapshots:
 
   protoc@32.1.0: {}
 
-  pump@3.0.3:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
-
   punycode@2.3.1: {}
 
   pure-conditions@1.2.3: {}
-
-  quick-lru@5.1.1: {}
 
   rc-cascader@3.34.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -5725,8 +5374,6 @@ snapshots:
 
   resize-observer-polyfill@1.5.1: {}
 
-  resolve-alpn@1.2.1: {}
-
   resolve-from@4.0.0: {}
 
   resolve@1.22.11:
@@ -5735,21 +5382,7 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  responselike@2.0.1:
-    dependencies:
-      lowercase-keys: 2.0.0
-
   retry@0.12.0: {}
-
-  roarr@2.15.4:
-    dependencies:
-      boolean: 3.2.0
-      detect-node: 2.1.0
-      globalthis: 1.0.4
-      json-stringify-safe: 5.0.1
-      semver-compare: 1.0.0
-      sprintf-js: 1.1.3
-    optional: true
 
   rollup@4.53.3:
     dependencies:
@@ -5898,17 +5531,7 @@ snapshots:
     dependencies:
       compute-scroll-into-view: 3.1.1
 
-  semver-compare@1.0.0:
-    optional: true
-
-  semver@6.3.1: {}
-
   semver@7.7.3: {}
-
-  serialize-error@7.0.1:
-    dependencies:
-      type-fest: 0.13.1
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -5944,9 +5567,6 @@ snapshots:
   source-map@0.6.1: {}
 
   source-map@0.7.6: {}
-
-  sprintf-js@1.1.3:
-    optional: true
 
   stat-mode@1.0.0: {}
 
@@ -6064,9 +5684,6 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  type-fest@0.13.1:
-    optional: true
-
   typescript-eslint@8.49.0(eslint@9.39.2)(typescript@5.8.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.2)(typescript@5.8.3))(eslint@9.39.2)(typescript@5.8.3)
@@ -6084,11 +5701,10 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  undici-types@6.21.0: {}
-
   undici-types@7.16.0: {}
 
-  universalify@0.1.2: {}
+  undici@7.28.0:
+    optional: true
 
   universalify@2.0.1: {}
 
@@ -6174,11 +5790,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yauzl@2.10.0:
-    dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
 

--- a/src/inject/common/bilibili.ts
+++ b/src/inject/common/bilibili.ts
@@ -2,7 +2,7 @@ import { createLogger } from "../../common/log";
 import https from "https";
 import path from "path";
 import fs from "fs";
-import { app } from "electron";
+import { app, session } from "electron";
 
 const log = createLogger("Bilibili");
 export const createBilibiliServer = () => {
@@ -50,4 +50,36 @@ export const createBilibiliServer = () => {
     "host-rules",
     "MAP bilipc.bilibili.com localhost:3031"
   );
+  // Chromium 150+ no longer fully trusts --ignore-certificate-errors for
+  // certificate verification in navigation. Explicitly allow self-signed certs
+  // for the local HTTPS server (mapped from bilipc.bilibili.com).
+  app.on("certificate-error", (event, _webContents, url, _error, _certificate, callback) => {
+    if (url.startsWith("https://bilipc.bilibili.com") || url.startsWith("https://localhost:3031")) {
+      event.preventDefault();
+      callback(true);
+    } else {
+      callback(false);
+    }
+  });
+  // Chromium 150 NetworkService honors the system proxy. bilipc.bilibili.com is
+  // host-rules-mapped to localhost:3031; routed through the proxy it cannot be
+  // resolved (NXDOMAIN) and the proxy closes the connection -> ERR_CONNECTION_CLOSED
+  // (-100) -> blank window. Force bilipc + loopback to bypass the proxy. This
+  // whenReady callback is registered before index.ts's whenReady (which triggers
+  // loadURL), so the bypass is in effect before the main window navigates.
+  app.whenReady().then(() => {
+    // Electron setProxy defaults to mode=FIXED_SERVERS; omitting proxyRules
+    // means empty proxy → direct (no proxy at all), which would bypass the
+    // system proxy for ALL requests. Read the proxy URL from the environment
+    // so external API requests still go through the system proxy while
+    // bilipc/localhost bypass it via proxyBypassRules.
+    const proxyUrl = (
+      process.env.HTTPS_PROXY || process.env.HTTP_PROXY ||
+      process.env.https_proxy || process.env.http_proxy || ""
+    ).trim();
+    session.defaultSession.setProxy({
+      proxyRules: proxyUrl.replace(/^https?:\/\//i, "").replace(/\/+$/, "") || undefined,
+      proxyBypassRules: "bilipc.bilibili.com,localhost,127.0.0.1",
+    }).catch(() => {});
+  });
 };

--- a/tools/update-electron.sh
+++ b/tools/update-electron.sh
@@ -14,8 +14,11 @@ notice() {
   echo -e "\033[36m $1 \033[0m "
 }
 
-# 大于28.2.1有问题：https://github.com/msojocs/bilibili-linux/issues/170, https://github.com/electron/electron/issues/42519
-electron_version="28.2.1"
+# electron 43.1.1 (Chromium 150) for NVIDIA/Wayland GPU accel (rendering + VA-API video decode).
+# #42519 (screen.getCursorScreenPoint Linux regression, still OPEN) is bypassed by cursor-tool
+# (electron-tool.ts electronOverwriteAfterReady) on Wayland, so upgrading is safe for Wayland users.
+# https://github.com/msojocs/bilibili-linux/issues/170, https://github.com/electron/electron/issues/42519
+electron_version="43.1.1"
 if [ "$BUILD_ARCH" == "" ];then
   BUILD_ARCH="x64"
 elif [ "$BUILD_ARCH" == "amd64" ];then


### PR DESCRIPTION
---
name: 'NVIDIA GPU acceleration on Wayland: upgrade Electron to 43+ (Chromium 150)'
about: 'NVIDIA GPU rendering + VA-API NVDEC hardware video decode on Wayland'
title: 'feat: support NVIDIA GPU acceleration (Electron 43+)'
labels: enhancement
assignees: ''
---

## Background

On **NVIDIA GPU + Wayland** systems (e.g. GTX 1660 Ti / KDE Plasma), the current Electron 28 (Chromium 120) build has two GPU acceleration blockers:

1. **GPU rendering fallback**: `--use-gl=egl` crashes with "Passthrough is not supported" (exit 133). `--use-gl=angle --use-angle=gl` works but the GPU process may fall back to SwiftShader in some configurations.

2. **VA-API video decode blocked**: Chromium's `vaapi_wrapper` has a hard-coded check at `vaapi_wrapper.cc:130`:

   ```
   WARNING:vaapi_wrapper.cc:130] Should skip nVidia device named: nvidia-drm
   ```

   This causes Chromium to skip VA-API initialization on NVIDIA GPUs entirely. The GPU process shows `dec: 0%` in `nvidia-smi dmon`.

3. **System proxy conflict** (Chromium 150+): When a system proxy (e.g. Clash at `127.0.0.1:7897`) is active, the local debug domain `bilipc.bilibili.com` (host-rules → `localhost:3031`) goes through the proxy, which cannot resolve the fake domain and returns `ERR_CONNECTION_CLOSED (-100)` → blank window.

## Root Cause

### For VA-API decode

The feature `VaapiOnNvidiaGPUs` (introduced in Chromium 130) is required to bypass the NVIDIA device skip in `vaapi_wrapper`. This feature **does not exist** in Chromium 120 (Electron 28).

Additionally, Chromium 150 renamed the VA-API decode feature from `VaapiVideoDecoder` (the old name used in Chromium 120) to `AcceleratedVideoDecodeLinuxGL` / `AcceleratedVideoDecodeLinuxZeroCopyGL`.

### For the proxy issue

Chromium 150's NetworkService (out-of-process network stack) honors the system proxy unconditionally. `--proxy-bypass-rules` command-line flag does not override system proxy settings. Must use `session.defaultSession.setProxy()` in the Electron main process with `proxyBypassRules` to bypass.

## Required Changes

### 1. Upgrade Electron from 28.2.1 → 43.1.1 (or ≥ 130)

- `conf/build.json`: `"electronVersion": "43.1.1"`
- `package.json`: `"electron": "^43.1.1"`
- `tools/update-electron.sh`: `electron_version="43.1.1"`

### 2. Add Chromium 150 certificate-error handler

Chromium 150 no longer fully trusts `--ignore-certificate-errors` for navigation. Must add an explicit `certificate-error` event handler:

```ts
app.on("certificate-error", (event, _webContents, url, _error, _certificate, callback) => {
  if (url.startsWith("https://bilipc.bilibili.com") || url.startsWith("https://localhost:3031")) {
    event.preventDefault();
    callback(true);
  } else {
    callback(false);
  }
});
```

### 3. Add proxy bypass for system proxy compatibility

```ts
app.whenReady().then(() => {
  const proxyUrl = (process.env.HTTPS_PROXY || process.env.HTTP_PROXY || "").trim();
  session.defaultSession.setProxy({
    proxyRules: proxyUrl.replace(/^https?:\/\//i, "").replace(/\/+$/, "") || undefined,
    proxyBypassRules: "bilipc.bilibili.com,localhost,127.0.0.1",
  }).catch(() => {});
});
```

### 4. Update `bilibili-flags.conf` recommended options

Replace old `VaapiVideoDecoder` with new GPU/VA-API feature names:

```
--enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoDecodeLinuxZeroCopyGL,VaapiOnNvidiaGPUs,VaapiIgnoreDriverChecks,PlatformHEVCDecoderSupport
```

`VaapiOnNvidiaGPUs` is the critical new feature that enables VA-API → NVDEC hardware decode on NVIDIA GPUs.

## Compatibility Note

- Electron 43's screen cursor regression (#42519) is **bypassed** on Wayland via the existing `cursor-tool` binary (reads `/dev/input/event*` directly), so upgrading is safe for Wayland users.
- X11 users may still be affected by #42519 and should test before upgrading.

## Reference Fork

A working fork with all changes applied is available at:
https://github.com/wings1848/bilibili-linux/tree/feat/electron43-gpu

The GPU acceleration has been verified:
- ✅ GPU rendering: NVIDIA (gpu-process 379 MiB VRAM, `sm 14-15%`)
- ✅ NVDEC hardware decode: `dec 5-7%` on HEVC video
- ✅ No blank screen / SSL errors
- ✅ System proxy preserved (bypass only bilipc/localhost)