### PR TITLE
fix: MutationObserver 仅遍历新增节点，彻底修复合集切集卡顿（对所有语言生效）

### DIFF
--- a/src/extension/page/translation.ts
+++ b/src/extension/page/translation.ts
@@ -179,12 +179,22 @@ const registerLanguageHandle = async () => {
   
 
   const observer = new MutationObserver((mutations) => {
+    // 中文环境不翻译，直接跳过，避免无意义的全量 DOM 遍历（切集时会导致主线程长时间阻塞）
+    if (!currentDict) return
     // log.info('[MutationObserver]: mutations', mutations);
     mutations.forEach((mutation) => {
       if (mutation.type === 'childList') {
         const node = mutation.target
+        // 只处理新增的节点，避免每次都对 mutation.target 的整棵子树做 O(n²) 遍历
+        // （切集重建 DOM 时会导致渲染主线程长时间阻塞）
+        const list: (HTMLElement | Node)[] = []
+        const seen = new Set<Node>()
+        for (const added of mutation.addedNodes) {
+          if (!added || seen.has(added)) continue
+          seen.add(added)
+          list.push(...getSingleNode(added as HTMLElement))
+        }
         if (node.nodeType === Node.ELEMENT_NODE && node instanceof HTMLElement) {
-          const list = getSingleNode(node)
           // log.info('list:', list)
           for (const item of list) {
             if (!item.textContent) continue
@@ -196,7 +206,6 @@ const registerLanguageHandle = async () => {
             translate(item as HTMLElement);
           }
         } else if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE && node instanceof ShadowRoot) {
-          const list = getSingleNode(node)
           // log.info('list:', list)
           for (const item of list) {
             if (!item.textContent) continue


### PR DESCRIPTION
Fixes #215 

## 问题现象

播放超大合集（如 995 视频合集）时，切换视频 / 自动连播会黑屏卡顿 13-17 秒：有声音无画面，之后画面突然出现。单视频切换不卡。

## 根因

`src/extension/page/translation.ts` 的 MutationObserver 监听整个 `document.body` + 所有 shadow root，每次 `childList` 变化都会调用 `getSingleNode(mutation.target)`——**递归遍历 mutation.target 的整个子树**（对每个节点做 18 个 `className.includes` + 4 个正则检查）。切集时播放器重建整个视频 DOM，产生大量 mutation，每个都触发全子树遍历 → **O(n²) 性能爆炸**，渲染主线程被阻塞 13-17 秒。

CPU Profiler 证实：阻塞期间 `r @ page.js:281`（observer 回调）占 12-14 秒纯 JS，栈内全是 `getNamedItem`/`hasChildNodes`/`querySelectorAll` 等 DOM 遍历。

## 修复

1. **核心：** childList 分支只对 `mutation.addedNodes`（实际新增的节点）调用 `getSingleNode`，并做去重——不再遍历 mutation.target 的整个子树，从 O(n²) 降为 O(新增节点数)。**对所有语言生效**。
2. **快速路径：** 默认中文环境（`currentDict` 为 undefined，翻译模块本就不工作）在 observer 回调开头直接 return，完全跳过 DOM 遍历。

保留 ShadowRoot 分支的 part/exportparts 逻辑，翻译功能不受影响。

## 验证

环境：bilibili-linux（Electron 43.1.1），Fedora 44 Wayland。注入 50ms 心跳监测渲染主线程阻塞：

- **修复前：** 每次切集主线程冻结 **13.1s / 13.5s / 17.5s**（三次 CPU Profiler 复现）
- **修复后（中文环境）：** 切集无阻塞
- **修复后（英文环境，`currentDict` 激活、翻译全功能运行）：** 120 秒内 3 次切集/自动连播，5043 个心跳样本 **0 个大 gap（>1000ms）**
